### PR TITLE
fix: update figure rendering after FigureWorkerMainThread removal (web)

### DIFF
--- a/packages/web/src/Client/Themes/default/Components/Community/CommunityUser.tsx
+++ b/packages/web/src/Client/Themes/default/Components/Community/CommunityUser.tsx
@@ -3,7 +3,7 @@ import Skeleton from '../../Images/community/habbo_skeleton.gif';
 
 // TODO: add type declarations
 //@ts-expect-error
-import { FigureAssets, Figure, FigureWorkerMainThread } from "@pixel63/game";
+import { FigureAssets, Figure } from "@pixel63/game";
 
 type UserProps = {
     name?: string | null;
@@ -19,7 +19,7 @@ const CommunityUser = ({ name = null, motto = null, figureConfiguration = null }
             FigureAssets.loadAssets().then(() => {
                 const figure = new Figure(figureConfiguration, 4);
 
-                figure.renderToCanvas(new FigureWorkerMainThread(), 0, false).then(({ figure }: any) => {
+                figure.renderToCanvas(new Figure(), 0, false).then(({ figure }: any) => {
                     const context = figureCanvasRef.current?.getContext("2d");
 
                     if(!context) {

--- a/packages/web/src/Client/Themes/default/Components/Community/CommunityUser.tsx
+++ b/packages/web/src/Client/Themes/default/Components/Community/CommunityUser.tsx
@@ -19,7 +19,7 @@ const CommunityUser = ({ name = null, motto = null, figureConfiguration = null }
             FigureAssets.loadAssets().then(() => {
                 const figure = new Figure(figureConfiguration, 4);
 
-                figure.renderToCanvas(new Figure(), 0, false).then(({ figure }: any) => {
+                figure.renderToCanvas(0, false).then(({ figure }: any) => {
                     const context = figureCanvasRef.current?.getContext("2d");
 
                     if(!context) {

--- a/packages/web/src/Client/Themes/default/Pages/MePage/MePage.tsx
+++ b/packages/web/src/Client/Themes/default/Pages/MePage/MePage.tsx
@@ -14,7 +14,7 @@ import UnknowUserImage from '../../Images/unknow_user.gif';
 
 // TODO: add type declarations
 //@ts-expect-error
-import { FigureAssets, Figure, FigureWorkerMainThread } from "@pixel63/game";
+import { FigureAssets, Figure } from "@pixel63/game";
 
 const MePage = () => {
     const navigate = useNavigate();
@@ -33,7 +33,7 @@ const MePage = () => {
                 FigureAssets.loadAssets().then(() => {
                     const figure = new Figure(currentUser.figureConfiguration, 2);
 
-                    figure.renderToCanvas(new FigureWorkerMainThread(), 0, false).then(({ figure }: any) => {
+                    figure.renderToCanvas(new Figure(), 0, false).then(({ figure }: any) => {
                         const context = figureCanvasRef.current?.getContext("2d");
 
                         if(!context) {

--- a/packages/web/src/Client/Themes/default/Pages/MePage/MePage.tsx
+++ b/packages/web/src/Client/Themes/default/Pages/MePage/MePage.tsx
@@ -33,7 +33,7 @@ const MePage = () => {
                 FigureAssets.loadAssets().then(() => {
                     const figure = new Figure(currentUser.figureConfiguration, 2);
 
-                    figure.renderToCanvas(new Figure(), 0, false).then(({ figure }: any) => {
+                    figure.renderToCanvas(0, false).then(({ figure }: any) => {
                         const context = figureCanvasRef.current?.getContext("2d");
 
                         if(!context) {


### PR DESCRIPTION
## Summary

Fixes build errors in the web package caused by the removal of `FigureWorkerMainThread` from `@pixel63/game`.

## Changes

* Replaced usage of `FigureWorkerMainThread` with `Figure`
* Updated figure rendering logic in:

  * `CommunityUser`
  * `MePage`

## Reason

`FigureWorkerMainThread` no longer exists in the game package, which caused build failures in the web package.

## Affected packages

* web

## How to test

1. Build the web project
2. Open pages that render avatars (e.g. Me Page, Community User)
3. Verify that avatars render correctly without errors