### PR TITLE
Fix/wired slider min value

### DIFF
--- a/packages/game/src/UserInterface/Common/Dialog/Layouts/Wired/Slider/WiredSlider.tsx
+++ b/packages/game/src/UserInterface/Common/Dialog/Layouts/Wired/Slider/WiredSlider.tsx
@@ -26,7 +26,7 @@ export default function WiredSlider({ min, max, value, step, onChange }: WiredSl
             }} onClick={() => onChange(Math.max(min, value - (step ?? 1)))}/>
 
             <div className="wired-slider sprite_dialog_wired_slider-background">
-                <input type="range" step={step} min={min} max={max} value={value} onChange={(event) => onChange(Math.max(0.5, Math.floor(parseFloat((event.target as HTMLInputElement).value))))}/>
+                <input type="range" step={step} min={min} max={max} value={value} onChange={(event) => onChange(Math.max(min, Math.floor(parseFloat((event.target as HTMLInputElement).value))))}/>
             </div>
 
             <div className="sprite_dialog_wired_arrow-right" style={{


### PR DESCRIPTION
## Summary

Fixes an issue where the `WiredSlider` component did not respect the provided `min` value.

## Changes

* Replaced hardcoded `0.5` with the `min` prop in the `onChange` handler

## Before

The slider would clamp values using a fixed minimum of `0.5`, ignoring the configured `min` prop.

## After

The slider now correctly respects the `min` value provided via props.

## Related

Closes #17

## Affected packages

* game

## How to test

1. Use `WiredSlider` with a custom `min` value (e.g. `min={2}`)
2. Move the slider to the lowest value
3. Verify it does not go below the defined `min`
