### PR TITLE
fix: limit chat input to 100 characters (game)

### DIFF
--- a/packages/game/src/UserInterface/components/Toolbar/Chatbar/ToolbarChatbar.tsx
+++ b/packages/game/src/UserInterface/components/Toolbar/Chatbar/ToolbarChatbar.tsx
@@ -166,6 +166,7 @@ export default function ToolbarChatbar({ style }: ToolbarChatbarProps) {
                 onChange={(event) => setValue((event.target as HTMLInputElement).value)}
                 onKeyUp={(event) => event.key === "Enter" && handleSubmit()}
                 placeholder="Click here to chat..."
+                maxLength={100}
                 style={{
                     flex: 1,
                     border: "none",

--- a/packages/server/src/Communication/Game/Rooms/User/SendUserMessageEvent.ts
+++ b/packages/server/src/Communication/Game/Rooms/User/SendUserMessageEvent.ts
@@ -15,6 +15,10 @@ export default class SendUserMessageEvent implements ProtobuffListener<SendRoomC
             throw new Error("Message is empty.");
         }
 
+        if(payload.message.length > 100) {
+            throw new Error("Message exceeds 100 characters.");
+        }
+
         const roomUser = user.room.getRoomUser(user);
 
         roomUser.lastActivity = performance.now();


### PR DESCRIPTION
## Summary

Adds a maximum length constraint to the chat input in `ToolbarChatbar`.

## Changes

* Added `maxLength={100}` to the chat input field

## Reason

The chat input previously allowed unlimited characters, which differs from the behavior of the original Habbo client.

This change:

* Aligns with expected client behavior
* Prevents excessively long messages
* Resolves the reported issue

## Related

Closes #10

## Affected packages

* game

## How to test

1. Click in the chat input in-game
2. Try typing more than 100 characters
3. Verify that input is limited to 100 characters