### PR TITLE
fix: reset moodlight/toner and close dialogs when furniture is removed (game)

### DIFF
--- a/packages/game/src/Client/Room/RoomInstance.ts
+++ b/packages/game/src/Client/Room/RoomInstance.ts
@@ -351,6 +351,21 @@ export default class RoomInstance {
         this.roomRenderer.items.splice(this.roomRenderer.items.indexOf(furniture.item), 1);
         this.furnitures.splice(this.furnitures.indexOf(furniture), 1);
 
+        if(this.clientInstance.dialogs.value) {
+            this.clientInstance.dialogs.value = this.clientInstance.dialogs.value.filter(
+                (dialog) => !(dialog.type === "room-furniture-logic" && (dialog.data as any)?.data?.id === roomFurnitureId)
+            );
+            this.clientInstance.dialogs.update();
+        }
+
+        if(furniture.furnitureData.interactionType === "background_toner") {
+            this.setBackgroundToner({ $type: 'UserFurnitureTonerData', enabled: false, color: "" });
+        }
+
+        if(furniture.furnitureData.interactionType === "dimmer") {
+            this.setMoodlight({ $type: 'UserFurnitureMoodlightData', enabled: false, color: "", alpha: 0, backgroundOnly: false });
+        }
+
         this.clientInstance.roomInstance.update();
     }
 

--- a/packages/game/src/Client/Room/RoomInstance.ts
+++ b/packages/game/src/Client/Room/RoomInstance.ts
@@ -12,7 +12,6 @@ import { RoomActorIdentifierData, RoomClickData, RoomDoubleClickData, RoomInform
 import RoomPet from "@Client/Room/Pets/RoomPet";
 import RoomPetItem from "@Client/Room/Items/Pets/RoomPetItem";
 import AssetFetcher from "@Client/Assets/AssetFetcher";
-import { RoomLogger } from "@pixel63/shared/Logger/Logger";
 import RoomDoubleClickEvent from "@Client/Events/RoomDoubleClickEvent";
 import RoomFurnitureStackHelperLogic from "@Client/Room/Furniture/Logic/RoomFurnitureStackHelperLogic";
 import ObservableProperty from "@Client/Utilities/ObservableProperty";
@@ -355,14 +354,15 @@ export default class RoomInstance {
             this.clientInstance.dialogs.value = this.clientInstance.dialogs.value.filter(
                 (dialog) => !(dialog.type === "room-furniture-logic" && (dialog.data as any)?.data?.id === roomFurnitureId)
             );
+
             this.clientInstance.dialogs.update();
         }
 
-        if(furniture.furnitureData.interactionType === "background_toner") {
+        if(furniture.furnitureData.interactionType === "background_toner" && furniture.data.data?.toner?.enabled) {
             this.setBackgroundToner({ $type: 'UserFurnitureTonerData', enabled: false, color: "" });
         }
 
-        if(furniture.furnitureData.interactionType === "dimmer") {
+        if(furniture.furnitureData.interactionType === "dimmer" && furniture.data.data?.moodlight?.enabled) {
             this.setMoodlight({ $type: 'UserFurnitureMoodlightData', enabled: false, color: "", alpha: 0, backgroundOnly: false });
         }
 


### PR DESCRIPTION
## Summary

Fixes inconsistent room state and UI when furniture is removed (picked up), particularly for moodlight and background toner items.

## Changes

* Close `room-furniture-logic` dialog when the associated furniture is removed
* Reset background toner when removing furniture with `background_toner` interaction
* Reset moodlight when removing furniture with `dimmer` interaction

## Problem

Previously:

* Dialogs could remain open for furniture that no longer exists in the room
* Moodlight and background toner effects could persist after the furniture was removed

## Solution

* Remove dialogs associated with the removed furniture
* Reset visual effects when their corresponding furniture is removed

## Related

Closes #8

## Affected packages

* game

## How to test

1. Place a moodlight or background toner furniture
2. Activate it
4. Open its dialog
5. Pick up the furniture
6. Verify:

   * The dialog closes automatically
   * The room lighting resets to default
