### PR TITLE
fix: set walkThroughFurniture before path validation to fix teleport furniture bug

### DIFF
--- a/packages/server/src/Rooms/Actor/Path/RoomActorPath.ts
+++ b/packages/server/src/Rooms/Actor/Path/RoomActorPath.ts
@@ -164,6 +164,8 @@ export default class RoomActorPath {
             return false;
         }
 
+        this.walkThroughFurniture = walkThroughFurniture;
+
         if(!this.isNextPositionFree(path[0]!, path)) {
             onCancel?.();
 
@@ -171,7 +173,6 @@ export default class RoomActorPath {
         }
 
         this.path = path;
-        this.walkThroughFurniture = walkThroughFurniture;
         this.pathOnFinish = onFinish;
         this.pathOnCancel = onCancel;
         this.pathJump = jump;


### PR DESCRIPTION
## Summary

Fixes a pathfinding issue where teleport-related furniture interactions could fail due to incorrect validation order.

## Changes

* Moved assignment of `this.walkThroughFurniture` before the initial `isNextPositionFree` check in `walkTo`

## Problem

Previously, `isNextPositionFree` was called before `walkThroughFurniture` was set.

This caused:

* Incorrect path validation
* Teleport-related furniture interactions to fail because the path was treated as non-walkable

## Solution

Ensure `walkThroughFurniture` is assigned before validating the next position, so path checks correctly respect the intended behavior.

## Affected packages

* server

## How to test

1. Use a teleport item
3. Verify that:

   * Path is not incorrectly cancelled
   * Movement works as expected
