### PR TITLE
fix: prevent click actions while dragging camera (game)

### DIFF
--- a/packages/game/src/Client/Room/Cursor/RoomCursor.ts
+++ b/packages/game/src/Client/Room/Cursor/RoomCursor.ts
@@ -117,6 +117,10 @@ export default class RoomCursor extends EventTarget {
         if(this.cursorDisabled) {
             return;
         }
+
+        if(this.roomRenderer.camera.dragged) {
+            return;
+        }
         
         const floorEntity = this.roomRenderer.getItemAtPosition((item) => item.type === "floor");
         const otherEntity = this.roomRenderer.getItemAtPosition((item) => item.type !== "floor" && item.type !== "wall");

--- a/packages/game/src/Client/Room/Cursor/RoomCursor.ts
+++ b/packages/game/src/Client/Room/Cursor/RoomCursor.ts
@@ -118,7 +118,7 @@ export default class RoomCursor extends EventTarget {
             return;
         }
 
-        if(this.roomRenderer.camera.dragged) {
+        if(this.roomRenderer.camera.dragging) {
             return;
         }
         

--- a/packages/game/src/Client/Room/RoomCamera.ts
+++ b/packages/game/src/Client/Room/RoomCamera.ts
@@ -4,6 +4,8 @@ import RoomRenderer from "./RoomRenderer";
 export default class RoomCamera {
     private moving: boolean = false;
 
+    public dragged: boolean = false;
+
     private lastPosition: MousePosition | null = null;
 
     public mousePosition: MousePosition | null = null;
@@ -40,6 +42,7 @@ export default class RoomCamera {
         }
 
         this.moving = true;
+        this.dragged = false;
 
         this.lastPosition = {
             left: event.pageX,
@@ -64,6 +67,10 @@ export default class RoomCamera {
 
         this.cameraPosition.left += relativePosition.left;
         this.cameraPosition.top += relativePosition.top;
+
+        if(Math.abs(relativePosition.left) > 2 || Math.abs(relativePosition.top) > 2) {
+            this.dragged = true;
+        }
 
         this.lastPosition = {
             left: event.pageX,

--- a/packages/game/src/Client/Room/RoomCamera.ts
+++ b/packages/game/src/Client/Room/RoomCamera.ts
@@ -4,7 +4,7 @@ import RoomRenderer from "./RoomRenderer";
 export default class RoomCamera {
     private moving: boolean = false;
 
-    public dragged: boolean = false;
+    public dragging: boolean = false;
 
     private lastPosition: MousePosition | null = null;
 
@@ -42,7 +42,7 @@ export default class RoomCamera {
         }
 
         this.moving = true;
-        this.dragged = false;
+        this.dragging = false;
 
         this.lastPosition = {
             left: event.pageX,
@@ -69,7 +69,7 @@ export default class RoomCamera {
         this.cameraPosition.top += relativePosition.top;
 
         if(Math.abs(relativePosition.left) > 2 || Math.abs(relativePosition.top) > 2) {
-            this.dragged = true;
+            this.dragging = true;
         }
 
         this.lastPosition = {

--- a/packages/game/src/Client/Room/RoomCamera.ts
+++ b/packages/game/src/Client/Room/RoomCamera.ts
@@ -83,6 +83,7 @@ export default class RoomCamera {
 
         this.moving = false;
         this.lastPosition = null;
+        this.dragging = false;
     }
 
     private mouseleave() {


### PR DESCRIPTION
## Summary

Prevents unintended click actions when dragging the camera.

## Changes

* Added a `dragged` flag to `RoomCamera`
* Updated `RoomCursor` to ignore click events when dragging occurs

## Problem

Previously, dragging the camera could still trigger click interactions, causing unintended actions such as:

* Moving the character
* Interacting with furniture

## Solution

Track whether the mouse movement qualifies as a drag and ignore click events when dragging is detected.

## Affected packages

* game

## How to test

1. Click and drag to move the camera

2. Release the mouse

3. Verify that:

   * No click action is triggered
   * Character does not move unintentionally

4. Perform a normal click without dragging

5. Verify that:

   * Click actions still work as expected
