### PR TITLE
fix: prevent crash when purchasing from shop outside a room

### DIFF
--- a/packages/game/src/UserInterface/components/Inventory/FlyingFurniture/FlyingFurnitureIcon.tsx
+++ b/packages/game/src/UserInterface/components/Inventory/FlyingFurniture/FlyingFurnitureIcon.tsx
@@ -27,7 +27,9 @@ export default function FlyingFurnitureIcon({ data, onFinish }: FlyingFurnitureI
         const targetElement = document.getElementById(data.targetElementId);
 
         if(!targetElement) {
-            throw new Error("Target element does not exist.");
+            onFinish();
+
+            return;
         }
 
         elementRef.current.style.left = `${data.position.left}px`;


### PR DESCRIPTION
## Summary

Prevents a crash when creating a flying furniture icon while the target element is not present in the DOM.

## Changes

* Replaced thrown error when `targetElement` is missing with a safe fallback:

  * Call `onFinish()`
  * Exit early

## Problem

Previously, when purchasing furniture outside a room:

* The target element (e.g. inventory) might not exist
* This caused an exception to be thrown
* The game would crash

## Solution

Gracefully handle the missing target element by:

* Skipping the animation
* Finishing the process without throwing an error

## Affected packages

* game

## How to test

1. Purchase a item from shop outside a room
2. Verify:

   * No crash occurs
   * No flying icon is shown (expected)
3. Perform the same action inside a room
4. Verify:

   * Animation still works correctly
