### PR TITLE
fix: Large furniture cropping for both inventory and shop preview

### DIFF
--- a/packages/game/src/Client/Room/RoomFurnitureRenderer.tsx
+++ b/packages/game/src/Client/Room/RoomFurnitureRenderer.tsx
@@ -58,6 +58,8 @@ export default class RoomFurnitureRenderer {
                         top: (this.roomItem.position?.depth ?? 0) * 32
                     });
                 }
+
+                this.roomRenderer.updatePreviewScale();
             }
         });
 

--- a/packages/game/src/Client/Room/RoomRenderer.ts
+++ b/packages/game/src/Client/Room/RoomRenderer.ts
@@ -44,6 +44,7 @@ export default class RoomRenderer extends EventTarget {
     private terminated = false;
 
     public scale: number = 1;
+    public previewScale: number = 1;
 
     public size: number = 64;
     private currentSize: number = 64;
@@ -231,8 +232,19 @@ export default class RoomRenderer extends EventTarget {
         this.drawBackground(context);
 
         this.updateRenderedOffset();
-        
+
+        if(this.previewScale !== 1) {
+            context.save();
+            context.translate(this.center.left, this.center.top);
+            context.scale(this.previewScale, this.previewScale);
+            context.translate(-this.center.left, -this.center.top);
+        }
+
         this.drawSprites(context, this.sortedSprites);
+
+        if(this.previewScale !== 1) {
+            context.restore();
+        }
 
         this.drawLightingForeground(context);
 
@@ -429,6 +441,67 @@ export default class RoomRenderer extends EventTarget {
             
             this.camera.cameraPosition.left = position.left + 64 + offset.left;
             this.camera.cameraPosition.top = -position.top + offset.top;
+        }
+    }
+
+    public updatePreviewScale() {
+        const furnitureItem = this.items.find(
+            (item): item is RoomFurnitureItem => item instanceof RoomFurnitureItem
+        );
+
+        if(!furnitureItem) {
+            this.previewScale = 1;
+            return;
+        }
+
+        let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+        let hasSprites = false;
+
+        for(const roomSprite of furnitureItem.sprites) {
+            if(!(roomSprite instanceof RoomFurnitureSprite)) {
+                continue;
+            }
+
+            const s = roomSprite.sprite;
+            if(!s.image) {
+                continue;
+            }
+
+            const offset = RoomFurnitureSprite.getDefaultOffsetPosition(furnitureItem.furnitureRenderer, s, 1);
+
+            minX = Math.min(minX, offset.left);
+            minY = Math.min(minY, offset.top);
+            maxX = Math.max(maxX, offset.left + s.image.width);
+            maxY = Math.max(maxY, offset.top + s.image.height);
+            hasSprites = true;
+        }
+
+        if(!hasSprites) {
+            return;
+        }
+
+        const furnitureWidth = maxX - minX;
+        const furnitureHeight = maxY - minY;
+
+        const canvasWidth = this.element.width;
+        const canvasHeight = this.element.height;
+
+        if(canvasWidth <= 0 || canvasHeight <= 0 || furnitureWidth <= 0 || furnitureHeight <= 0) {
+            return;
+        }
+
+        const padding = 20;
+        const scaleX = (canvasWidth - padding) / furnitureWidth;
+        const scaleY = (canvasHeight - padding) / furnitureHeight;
+        this.previewScale = Math.min(scaleX, scaleY, 1);
+
+        if(this.previewScale < 1 && furnitureItem.position) {
+            const screenPos = this.getCoordinatePosition(furnitureItem.position);
+            const spriteCenterX = (minX + maxX) / 2;
+            const spriteCenterY = (minY + maxY) / 2;
+
+            this.camera.cameraPosition.left = Math.round(-(screenPos.left + spriteCenterX));
+            this.camera.cameraPosition.top = Math.round(-(screenPos.top + spriteCenterY));
         }
     }
 

--- a/packages/game/src/UserInterface/Common/Room/RoomRenderer.tsx
+++ b/packages/game/src/UserInterface/Common/Room/RoomRenderer.tsx
@@ -30,9 +30,13 @@ export default function RoomRenderer({ hidden, structure, furniture }: RoomRende
 
         roomRendererRequested.current = true;
         
-        setRoomRenderer(
-            new ClientRoomRenderer(elementRef.current, undefined, undefined, structure)
-        );
+        const renderer = new ClientRoomRenderer(elementRef.current, undefined, undefined, structure);
+
+        renderer.addEventListener("render", () => {
+            renderer.updatePreviewScale();
+        });
+
+        setRoomRenderer(renderer);
 
         return () => {
             roomRenderer?.terminate();


### PR DESCRIPTION
## Summary

Fixes an issue where large furniture items (e.g. Epic Christmas Tree) are not fully visible in preview contexts such as inventory or shop.

## Problem

The renderer was always using a fixed scale, causing oversized furniture sprites to overflow outside the visible canvas area. This resulted in cropped previews and poor UX when inspecting large items.

## Solution

Introduced a `previewScale` system in `RoomRenderer` that dynamically adjusts rendering scale based on the bounding box of the furniture sprites.

### Key changes:
- Added `previewScale` property to `RoomRenderer`
- Implemented `updatePreviewScale()` to:
  - Calculate sprite bounds (min/max X/Y)
  - Determine optimal scale based on canvas size
  - Clamp scale to a maximum of 1 (no upscaling)
- Applied scaling via canvas transform during rendering:
  - `context.scale()` + centering logic
- Adjusted camera position to keep furniture centered when scaled down

## Result

- Large furniture now fits entirely within preview areas
- No cropping for oversized items
- Maintains original scale for normal-sized furniture

## Notes

- Scaling only applies when `previewScale !== 1`
- Does not affect in-room rendering behavior, only preview scenarios