### PR TITLE
fix: broken tile in some room models

### DIFF
--- a/packages/game/src/Client/Room/Items/Floor/RoomFloorSprite.ts
+++ b/packages/game/src/Client/Room/Items/Floor/RoomFloorSprite.ts
@@ -5,12 +5,12 @@ import RoomFloorItem from "../Map/RoomFloorItem";
 import { RoomPositionWithDirectionData } from "@pixel63/events";
 
 export default class RoomFloorSprite extends RoomSprite {
-    priority = -3000;
-
     private readonly offset: MousePosition;
 
-    constructor(public readonly item: RoomFloorItem, private readonly image: OffscreenCanvas) {
+    constructor(public readonly item: RoomFloorItem, private readonly image: OffscreenCanvas, elevated: boolean = false) {
         super(item);
+
+        this.priority = elevated ? -50 : -3000;
 
         this.offset = {
             left: -(this.item.floorRenderer.rows * 32),

--- a/packages/game/src/Client/Room/Items/Map/RoomFloorItem.ts
+++ b/packages/game/src/Client/Room/Items/Map/RoomFloorItem.ts
@@ -17,10 +17,14 @@ export default class RoomFloorItem extends RoomItem {
     }
 
     render() {
-        this.floorRenderer.renderOffScreen().then(({ floor, shadow }) => {
+        this.floorRenderer.renderOffScreen().then(({ floor, elevatedFloor, shadow }) => {
             this.sprites = [];
 
             this.sprites.push(new RoomFloorSprite(this, this.renderWithLighting(floor)));
+
+            if(elevatedFloor) {
+                this.sprites.push(new RoomFloorSprite(this, this.renderWithLighting(elevatedFloor), true));
+            }
 
             if(shadow) {
                 this.sprites.push(new RoomFloorShadowSprite(this, shadow));

--- a/packages/game/src/Client/Room/Structure/FloorRenderer.ts
+++ b/packages/game/src/Client/Room/Structure/FloorRenderer.ts
@@ -156,12 +156,40 @@ export default class FloorRenderer {
 
         this.tiles = [];
 
-        for(let currentDepth = 0; currentDepth <= this.depth; currentDepth++) {
-            const currentRectangles = rectangles.filter((rectangle) => Math.ceil(rectangle.depth) === currentDepth);
+        const doorDepth = this.structure.door
+            ? this.parseDepth(this.getTileDepth(this.structure.door.row, this.structure.door.column))
+            : 0;
+        const groundLevel = doorDepth === 'X' ? 0 : doorDepth;
+
+        const groundRectangles = rectangles.filter((rectangle) => Math.ceil(rectangle.depth) <= groundLevel);
+        const elevatedRectangles = rectangles.filter((rectangle) => Math.ceil(rectangle.depth) > groundLevel);
+
+        for(let currentDepth = 0; currentDepth <= groundLevel; currentDepth++) {
+            const currentRectangles = groundRectangles.filter((rectangle) => Math.ceil(rectangle.depth) === currentDepth);
 
             this.renderLeftEdges(context, currentRectangles, leftEdgeImage.image);
             this.renderRightEdges(context, currentRectangles, rightEdgeImage.image);
             this.renderTiles(context, currentRectangles, tileImage.image);
+        }
+
+        let elevatedCanvas: OffscreenCanvas | undefined = undefined;
+
+        if(elevatedRectangles.length > 0) {
+            elevatedCanvas = new OffscreenCanvas(width, height);
+
+            const elevatedContext = elevatedCanvas.getContext("2d");
+
+            if(!elevatedContext) {
+                throw new ContextNotAvailableError();
+            }
+
+            for(let currentDepth = groundLevel + 1; currentDepth <= this.depth; currentDepth++) {
+                const currentRectangles = elevatedRectangles.filter((rectangle) => Math.ceil(rectangle.depth) === currentDepth);
+
+                this.renderLeftEdges(elevatedContext, currentRectangles, leftEdgeImage.image);
+                this.renderRightEdges(elevatedContext, currentRectangles, rightEdgeImage.image);
+                this.renderTiles(elevatedContext, currentRectangles, tileImage.image);
+            }
         }
 
         let shadowCanvas: OffscreenCanvas | undefined = undefined;
@@ -177,10 +205,15 @@ export default class FloorRenderer {
 
             shadowContext.filter = "blur(10px) brightness(0%) opacity(50%)";
             shadowContext.drawImage(canvas, 0, 10);
+
+            if(elevatedCanvas) {
+                shadowContext.drawImage(elevatedCanvas, 0, 10);
+            }
         }
 
         return {
             floor: canvas,
+            elevatedFloor: elevatedCanvas,
             shadow: shadowCanvas
         };
     }

--- a/packages/game/src/UserInterface/components/Room/Map/RoomMapImage.tsx
+++ b/packages/game/src/UserInterface/components/Room/Map/RoomMapImage.tsx
@@ -35,11 +35,11 @@ export default function RoomMapImage({ crop = false, width, height, style, struc
             const floorRenderer = new FloorRenderer(structure, structure.floor?.id ?? "default", size);
             const wallRenderer = new WallRenderer(structure, structure.wall?.id ?? "default", size);
 
-            const [ floorImage, [wallImage, doorMaskImage] ] = await Promise.all([
+            const [ [ floor, elevatedFloor ], [wallImage, doorMaskImage] ] = await Promise.all([
                 (async () => {
-                    const { floor } = await floorRenderer.renderOffScreen();
+                    const { floor, elevatedFloor } = await floorRenderer.renderOffScreen();
 
-                    return floor;
+                    return [ floor, elevatedFloor ];
                 })(),
                 
                 (async () => {
@@ -52,7 +52,7 @@ export default function RoomMapImage({ crop = false, width, height, style, struc
                 })()
             ]);
 
-            const canvas = new OffscreenCanvas(Math.max(wallImage.width, floorImage.width), Math.max(wallImage.height, floorImage.height));
+            const canvas = new OffscreenCanvas(Math.max(wallImage.width, floor.width, elevatedFloor?.width ?? 0), Math.max(wallImage.height, floor.height, elevatedFloor?.height ?? 0));
 
             const context = canvas.getContext("2d");
 
@@ -63,7 +63,12 @@ export default function RoomMapImage({ crop = false, width, height, style, struc
             context.translate((floorRenderer.rows * fullSize), (wallRenderer.depth + 3.5) * fullSize);
 
             context.drawImage(wallImage, -(wallRenderer.rows * fullSize), -((wallRenderer.depth + 3.5) * fullSize) - (wallRenderer.structure.wall?.thickness ?? 0));
-            context.drawImage(floorImage, -(floorRenderer.rows * fullSize), -(floorRenderer.depth * fullSize) - fullSize - (floorRenderer.structure.wall?.thickness ?? 0));
+            context.drawImage(floor, -(floorRenderer.rows * fullSize), -(floorRenderer.depth * fullSize) - fullSize - (floorRenderer.structure.wall?.thickness ?? 0));
+            
+            if(elevatedFloor) {
+                context.drawImage(elevatedFloor, -(floorRenderer.rows * fullSize), -(floorRenderer.depth * fullSize) - fullSize - (floorRenderer.structure.wall?.thickness ?? 0));
+            }
+
             context.drawImage(doorMaskImage, -(wallRenderer.rows * fullSize), -((wallRenderer.depth + 3.5) * fullSize) - (wallRenderer.structure.wall?.thickness ?? 0));
 
             const resultContext = canvasRef.current?.getContext("2d");


### PR DESCRIPTION
## Summary

Fixes broken tile in some room models caused by RoomDoorMaskSprite priority over RoomFloorSprite so divided the floor rendering method to split into ground level (same as door) and elevated level, with the elevated RoomFloorSprite having priority over RoomDoorMaskSprite

## Changes

* Add `elevated` flag to `RoomFloorSprite` to control rendering priority
* Adjust floor sprite priority dynamically (`-3000` → ground, `-50` → elevated)
* Refactor `FloorRenderer.renderOffScreen()` to split rendering into:
  * ground layer
  * elevated layer (`elevatedFloor`)
* Update shadow rendering to include elevated floor layer

## Problem

Previously:

* `RoomDoorMaskSprite` could render above floor tiles
* Elevated floors near doors appeared visually broken or cut off
* Some room models displayed incorrect tile layering

## Solution

* Detect ground level based on door tile depth
* Render elevated tiles separately from ground tiles
* Ensure elevated floor sprites have higher priority than the door mask
* Include elevated tiles in shadow rendering

## Related

Closes #11

## Affected packages

* game

## How to test

1. Load a room with elevation differences (platforms or raised tiles)
2. Ensure there is a door on a lower level
3. Observe tiles near the door
4. Verify:

   * Elevated tiles render correctly above the door mask
   * No tiles appear cut or hidden incorrectly
   * Shadows render properly for all floor levels