### PR TITLE
feat: add mouse interactions to dialog scrollbar

### DIFF
--- a/packages/game/src/UserInterface/Common/Dialog/Components/Scroll/DialogScrollbar.tsx
+++ b/packages/game/src/UserInterface/Common/Dialog/Components/Scroll/DialogScrollbar.tsx
@@ -231,9 +231,13 @@ export default function DialogScrollbar({ reversed, containerRef, hideInactive }
                     transform: "rotateZ(180deg)",
                     cursor: active ? "pointer" : undefined,
                 }}
-                onMouseDown={(e) => {
-                    if(!active) return;
-                    e.preventDefault();
+                onMouseDown={(event) => {
+                    if(!active) {
+                        return;
+                    }
+
+                    event.preventDefault();
+                    
                     scrollBy(ARROW_SCROLL_AMOUNT);
                 }}
             />

--- a/packages/game/src/UserInterface/Common/Dialog/Components/Scroll/DialogScrollbar.tsx
+++ b/packages/game/src/UserInterface/Common/Dialog/Components/Scroll/DialogScrollbar.tsx
@@ -12,7 +12,6 @@ const scrollBackgroundImageEnabled = new URL('../../../../Images/dialog/scroll/e
 const scrollBackgroundImageDisabled = new URL('../../../../Images/dialog/scroll/disabled_background.png', import.meta.url);
 
 const ARROW_SCROLL_AMOUNT = 30;
-const DRAG_SPEED_MULTIPLIER = 2;
 
 export default function DialogScrollbar({ reversed, containerRef, hideInactive }: DialogScrollbarProps) {
     const handleContainerRef = useRef<HTMLDivElement>(null);
@@ -86,15 +85,20 @@ export default function DialogScrollbar({ reversed, containerRef, hideInactive }
     const scrollBy = useCallback((amount: number) => {
         if(!containerRef.current) return;
 
-        const direction = reversed ? -1 : 1;
+        const direction = (reversed)?(-1):(1);
+
         containerRef.current.scrollTop += amount * direction;
     }, [containerRef, reversed]);
 
-    const onTrackClick = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
+    const onTrackClick = useCallback((event: React.MouseEvent<HTMLDivElement>) => {
         if(!containerRef.current || !handleContainerRef.current || isDragging.current) return;
 
+        if((event.target as HTMLDivElement).classList.contains('dialog-scroll-bar-handle')) {
+            return;
+        }
+
         const trackRect = handleContainerRef.current.getBoundingClientRect();
-        const clickY = e.clientY - trackRect.top;
+        const clickY = event.clientY - trackRect.top;
         const trackHeight = trackRect.height;
 
         const clickPercentage = clickY / trackHeight;
@@ -122,21 +126,20 @@ export default function DialogScrollbar({ reversed, containerRef, hideInactive }
     }, [containerRef]);
 
     useEffect(() => {
-        const onMouseMove = (e: MouseEvent) => {
-            if(!isDragging.current || !containerRef.current || !handleContainerRef.current) return;
+        const onMouseMove = (event: MouseEvent) => {
+            if(!isDragging.current || !containerRef.current || !handleContainerRef.current) {
+                return;
+            }
 
             const trackHeight = handleContainerRef.current.clientHeight;
             const container = containerRef.current;
-            const maxScroll = container.scrollHeight - container.clientHeight;
 
-            const deltaY = e.clientY - dragStartY.current;
-            const scrollRatio = (maxScroll / trackHeight) * DRAG_SPEED_MULTIPLIER;
+            const fullContainerHeight = containerRef.current.scrollHeight;
 
-            if(reversed) {
-                container.scrollTop = dragStartScrollTop.current - (deltaY * scrollRatio);
-            } else {
-                container.scrollTop = dragStartScrollTop.current + (deltaY * scrollRatio);
-            }
+            const deltaY = ((dragStartScrollTop.current / fullContainerHeight) * trackHeight) + (event.clientY - dragStartY.current);
+            const scrollPosition = (deltaY / trackHeight) * (fullContainerHeight);
+
+            container.scrollTop = scrollPosition;
         };
 
         const onMouseUp = () => {
@@ -151,7 +154,7 @@ export default function DialogScrollbar({ reversed, containerRef, hideInactive }
             document.removeEventListener("mousemove", onMouseMove);
             document.removeEventListener("mouseup", onMouseUp);
         };
-    }, [containerRef, reversed]);
+    }, [containerRef]);
 
     return (
         <div style={{
@@ -163,9 +166,13 @@ export default function DialogScrollbar({ reversed, containerRef, hideInactive }
             <div
                 className={(active)?("sprite_dialog_scroll_enabled_top"):("sprite_dialog_scroll_disabled_top")}
                 style={{ cursor: active ? "pointer" : undefined }}
-                onMouseDown={(e) => {
-                    if(!active) return;
-                    e.preventDefault();
+                onMouseDown={(event) => {
+                    if(!active) {
+                        return;
+                    }
+                    
+                    event.preventDefault();
+
                     scrollBy(-ARROW_SCROLL_AMOUNT);
                 }}
             />
@@ -185,6 +192,7 @@ export default function DialogScrollbar({ reversed, containerRef, hideInactive }
             >
                 {(active) && (
                     <div
+                        className="dialog-scroll-bar-handle"
                         style={{
                             position: "absolute",
 
@@ -199,17 +207,19 @@ export default function DialogScrollbar({ reversed, containerRef, hideInactive }
                         }}
                         onMouseDown={onHandleMouseDown}
                     >
-                        <div className={"sprite_dialog_scroll_handle_top"}/>
+                        <div className={"sprite_dialog_scroll_handle_top"} style={{ pointerEvents: "none" }}/>
 
                         <div style={{
                             flex: 1,
 
                             width: "100%",
                             background: `url(${scrollHandleBackgroundImage.toString()})`,
+                            pointerEvents: "none"
                         }}/>
 
                         <div className={"sprite_dialog_scroll_handle_top"} style={{
-                            transform: "rotateZ(180deg)"
+                            transform: "rotateZ(180deg)",
+                            pointerEvents: "none"
                         }}/>
                     </div>
                 )}

--- a/packages/game/src/UserInterface/Common/Dialog/Components/Scroll/DialogScrollbar.tsx
+++ b/packages/game/src/UserInterface/Common/Dialog/Components/Scroll/DialogScrollbar.tsx
@@ -1,4 +1,4 @@
-import { RefObject, useEffect, useRef, useState } from "react";
+import { RefObject, useCallback, useEffect, useRef, useState } from "react";
 
 export type DialogScrollbarProps = {
     containerRef: RefObject<HTMLDivElement | null>;
@@ -11,6 +11,9 @@ const scrollHandleBackgroundImage = new URL('../../../../Images/dialog/scroll/ha
 const scrollBackgroundImageEnabled = new URL('../../../../Images/dialog/scroll/enabled_background.png', import.meta.url);
 const scrollBackgroundImageDisabled = new URL('../../../../Images/dialog/scroll/disabled_background.png', import.meta.url);
 
+const ARROW_SCROLL_AMOUNT = 30;
+const DRAG_SPEED_MULTIPLIER = 2;
+
 export default function DialogScrollbar({ reversed, containerRef, hideInactive }: DialogScrollbarProps) {
     const handleContainerRef = useRef<HTMLDivElement>(null);
 
@@ -18,6 +21,10 @@ export default function DialogScrollbar({ reversed, containerRef, hideInactive }
 
     const [scrollPercentage, setScrollPercentage] = useState(0);
     const [containerHeightPercentage, setContainerHeightPercentage] = useState(100);
+
+    const isDragging = useRef(false);
+    const dragStartY = useRef(0);
+    const dragStartScrollTop = useRef(0);
 
     useEffect(() => {
         if(!containerRef.current) {
@@ -76,15 +83,92 @@ export default function DialogScrollbar({ reversed, containerRef, hideInactive }
         };
     }, [containerRef, handleContainerRef]);
 
+    const scrollBy = useCallback((amount: number) => {
+        if(!containerRef.current) return;
+
+        const direction = reversed ? -1 : 1;
+        containerRef.current.scrollTop += amount * direction;
+    }, [containerRef, reversed]);
+
+    const onTrackClick = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
+        if(!containerRef.current || !handleContainerRef.current || isDragging.current) return;
+
+        const trackRect = handleContainerRef.current.getBoundingClientRect();
+        const clickY = e.clientY - trackRect.top;
+        const trackHeight = trackRect.height;
+
+        const clickPercentage = clickY / trackHeight;
+
+        const container = containerRef.current;
+        const maxScroll = container.scrollHeight - container.clientHeight;
+
+        if(reversed) {
+            container.scrollTop = -(clickPercentage * maxScroll);
+        } else {
+            container.scrollTop = clickPercentage * maxScroll;
+        }
+    }, [containerRef, reversed]);
+
+    const onHandleMouseDown = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
+        if(!containerRef.current || !handleContainerRef.current) return;
+
+        e.preventDefault();
+        e.stopPropagation();
+
+        isDragging.current = true;
+        dragStartY.current = e.clientY;
+        dragStartScrollTop.current = containerRef.current.scrollTop;
+        document.body.style.cursor = "grabbing";
+    }, [containerRef]);
+
+    useEffect(() => {
+        const onMouseMove = (e: MouseEvent) => {
+            if(!isDragging.current || !containerRef.current || !handleContainerRef.current) return;
+
+            const trackHeight = handleContainerRef.current.clientHeight;
+            const container = containerRef.current;
+            const maxScroll = container.scrollHeight - container.clientHeight;
+
+            const deltaY = e.clientY - dragStartY.current;
+            const scrollRatio = (maxScroll / trackHeight) * DRAG_SPEED_MULTIPLIER;
+
+            if(reversed) {
+                container.scrollTop = dragStartScrollTop.current - (deltaY * scrollRatio);
+            } else {
+                container.scrollTop = dragStartScrollTop.current + (deltaY * scrollRatio);
+            }
+        };
+
+        const onMouseUp = () => {
+            isDragging.current = false;
+            document.body.style.cursor = "";
+        };
+
+        document.addEventListener("mousemove", onMouseMove);
+        document.addEventListener("mouseup", onMouseUp);
+
+        return () => {
+            document.removeEventListener("mousemove", onMouseMove);
+            document.removeEventListener("mouseup", onMouseUp);
+        };
+    }, [containerRef, reversed]);
+
     return (
         <div style={{
             display: (hideInactive && !active)?("none"):("flex"),
             flexDirection: "column",
 
-            // TODO: add mouse events
-            pointerEvents: "none",
+            pointerEvents: "auto",
         }}>
-            <div className={(active)?("sprite_dialog_scroll_enabled_top"):("sprite_dialog_scroll_disabled_top")}/>
+            <div
+                className={(active)?("sprite_dialog_scroll_enabled_top"):("sprite_dialog_scroll_disabled_top")}
+                style={{ cursor: active ? "pointer" : undefined }}
+                onMouseDown={(e) => {
+                    if(!active) return;
+                    e.preventDefault();
+                    scrollBy(-ARROW_SCROLL_AMOUNT);
+                }}
+            />
 
             <div ref={handleContainerRef} style={{
                 flex: 1,
@@ -94,20 +178,27 @@ export default function DialogScrollbar({ reversed, containerRef, hideInactive }
                 width: "100%",
                 background: (active)?(`url(${scrollBackgroundImageEnabled.toString()})`):(`url(${scrollBackgroundImageDisabled.toString()})`),
 
-                position: "relative"
-            }}>
+                position: "relative",
+                cursor: active ? "pointer" : undefined,
+            }}
+                onClick={active ? onTrackClick : undefined}
+            >
                 {(active) && (
-                    <div style={{
-                        position: "absolute",
+                    <div
+                        style={{
+                            position: "absolute",
 
-                        top: (!reversed)?(`${scrollPercentage}%`):(undefined),
-                        bottom: (reversed)?(`${scrollPercentage}%`):(undefined),
+                            top: (!reversed)?(`${scrollPercentage}%`):(undefined),
+                            bottom: (reversed)?(`${scrollPercentage}%`):(undefined),
 
-                        height: `${containerHeightPercentage}%`,
+                            height: `${containerHeightPercentage}%`,
 
-                        display: "flex",
-                        flexDirection: "column"
-                    }}>
+                            display: "flex",
+                            flexDirection: "column",
+                            cursor: "grab",
+                        }}
+                        onMouseDown={onHandleMouseDown}
+                    >
                         <div className={"sprite_dialog_scroll_handle_top"}/>
 
                         <div style={{
@@ -124,9 +215,18 @@ export default function DialogScrollbar({ reversed, containerRef, hideInactive }
                 )}
             </div>
 
-            <div className={(active)?("sprite_dialog_scroll_enabled_top"):("sprite_dialog_scroll_disabled_top")} style={{
-                transform: "rotateZ(180deg)"
-            }}/>
+            <div
+                className={(active)?("sprite_dialog_scroll_enabled_top"):("sprite_dialog_scroll_disabled_top")}
+                style={{
+                    transform: "rotateZ(180deg)",
+                    cursor: active ? "pointer" : undefined,
+                }}
+                onMouseDown={(e) => {
+                    if(!active) return;
+                    e.preventDefault();
+                    scrollBy(ARROW_SCROLL_AMOUNT);
+                }}
+            />
         </div>
     );
 }


### PR DESCRIPTION
## Summary

Adds mouse interaction support to dialog scrollbar and improves scrolling behavior.

## Changes

* Implement click on scrollbar track to jump scroll position
* Add draggable scrollbar handle
* Add clickable top/bottom arrows for incremental scrolling
* Enable proper cursor feedback (pointer / grab / grabbing)

## Problem

Previously:

* Scrollbar was purely visual and not interactive
* Users could not click, drag, or use arrows to control scrolling
* No mouse feedback (cursor changes)
* Poor UX compared to expected scrollbar behavior

## Solution

* Implement full mouse interaction system:
  * Track click → jump to position
  * Handle drag → smooth scrolling
  * Arrow buttons → incremental scroll
* Add drag state handling using refs
* Sync scroll behavior with container scrollTop
* Ensure compatibility with reversed scroll layouts

## Related

Closes #15

## Affected packages

* game

## How to test

1. Open any dialog with scrollable content
2. Verify:
   * Clicking on scrollbar track moves scroll position
   * Dragging the handle scrolls content smoothly
   * Clicking top arrow scrolls up
   * Clicking bottom arrow scrolls down
   * Cursor changes correctly (pointer / grab / grabbing)