### PR TITLE
feat: allow clicking chat messages to open user info

### DIFF
--- a/packages/game/src/UserInterface/components/Room/Chat/RoomChat.tsx
+++ b/packages/game/src/UserInterface/components/Room/Chat/RoomChat.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import RoomChatRenderer from "@Client/Room/Chat/RoomChatRenderer";
 import { useRoomInstance } from "../../../Hooks/useRoomInstance";
 import { webSocketClient } from "../../../..";
@@ -215,12 +215,21 @@ export default function RoomChat() {
         };
     }, [messages.current.length]);
 
-    const onClickUserMessage = (message: RoomChatMessage) => {
-        if(message.userId && room) {
-            const roomUser = room.getUserById(message.userId);
+    const onClickUserMessage = useCallback((message: RoomChatMessage) => {
+        if(!room) {
+            return;
+        }
+
+        if(!message.userId) {
+            return;
+        }
+
+        const roomUser = room.users.find((user) => user.data.id === message.userId);
+
+        if(roomUser) {
             room.roomRenderer.focusedItem.value = roomUser.item;
         }
-    }
+    }, [room]);
 
     return (
         <div ref={rootRef} style={{

--- a/packages/game/src/UserInterface/components/Room/Chat/RoomChat.tsx
+++ b/packages/game/src/UserInterface/components/Room/Chat/RoomChat.tsx
@@ -247,8 +247,8 @@ export default function RoomChat() {
                         left: message.left,
                         bottom: message.index * 32,
                         transition: "bottom 320ms",
-                        cursor: message.userId ? "pointer" : "default",
-                        pointerEvents: message.userId ? "auto" : "none"
+                        cursor: (message.userId)?("pointer"):("default"),
+                        pointerEvents: (message.userId)?("auto"):("none")
                     }} onClick={() => onClickUserMessage(message)}>
                         <OffscreenCanvasRender offscreenCanvas={message.image}/>
                     </div>

--- a/packages/game/src/UserInterface/components/Room/Chat/RoomChat.tsx
+++ b/packages/game/src/UserInterface/components/Room/Chat/RoomChat.tsx
@@ -12,6 +12,7 @@ type RoomChatMessage = {
     image: ImageBitmap;
     left: number;
     index: number;
+    userId?: string;
 };
 
 function moveMessagesUp(messages: RoomChatMessage[], bottomMessage: RoomChatMessage) {
@@ -141,7 +142,8 @@ export default function RoomChat() {
                     id: Math.random(),
                     image,
                     left,
-                    index: -1
+                    index: -1,
+                    userId: payload.actor?.user?.userId
                 };
 
                 moveMessagesUp(messages.current, newMessage);
@@ -213,6 +215,13 @@ export default function RoomChat() {
         };
     }, [messages.current.length]);
 
+    const onClickUserMessage = (message: RoomChatMessage) => {
+        if(message.userId && room) {
+            const roomUser = room.getUserById(message.userId);
+            room.roomRenderer.focusedItem.value = roomUser.item;
+        }
+    }
+
     return (
         <div ref={rootRef} style={{
             position: "absolute",
@@ -228,8 +237,10 @@ export default function RoomChat() {
                         position: "absolute",
                         left: message.left,
                         bottom: message.index * 32,
-                        transition: "bottom 320ms"
-                    }}>
+                        transition: "bottom 320ms",
+                        cursor: message.userId ? "pointer" : "default",
+                        pointerEvents: message.userId ? "auto" : "none"
+                    }} onClick={() => onClickUserMessage(message)}>
                         <OffscreenCanvasRender offscreenCanvas={message.image}/>
                     </div>
                 );


### PR DESCRIPTION
## Summary

Adds the ability to click on chat messages to open and focus the corresponding user in the room.

## Changes

* Attach `userId` to chat messages from actors
* Enable pointer interaction only for messages associated with a user
* Add click handler to focus the corresponding room user
* Update cursor style to indicate clickable messages

## Problem

Previously:

* Chat messages were not interactive
* Users could not easily identify or interact with message senders
* No quick way to focus or inspect a user directly from chat

## Solution

* Store `userId` in chat message data
* Add click handler to resolve and focus the corresponding user
* Enable pointer events only for valid user messages
* Provide visual feedback via cursor change

## Affected packages

* game

## How to test

1. Enter a room with multiple users
2. Send messages from different users
3. Click on a chat message
4. Verify:
   * The cursor changes to pointer on hover
   * Clicking the message focuses the corresponding user
   * Non-user messages remain non-interactive